### PR TITLE
fixed typo

### DIFF
--- a/doc/preface.adoc
+++ b/doc/preface.adoc
@@ -88,6 +88,6 @@ of the https://github.com/stetre/moonglmath[official repository] on GitHub.
 [[see-also]]
 === See also
 
-MoonVulkan is part of https://github.com/stetre/moonlibs[MoonLibs], a collection of 
+MoonGLMATH is part of https://github.com/stetre/moonlibs[MoonLibs], a collection of 
 Lua libraries for graphics and audio programming.
 


### PR DESCRIPTION
MoonGLMATH was referred to as MoonVulkan